### PR TITLE
Set module entry file to correct build path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cddl",
   "version": "0.2.1",
   "description": "Concise data definition language (RFC 8610) implementation and JSON validator in Node.js",
-  "main": "index.js",
+  "main": "build/index.js",
   "bin": {
     "cddl": "./bin/cddl.js"
   },


### PR DESCRIPTION
This addresses the incorrect module entry file as discussed in #4.